### PR TITLE
BuffKit SCS 558 - ToggleMatchUI Fix

### DIFF
--- a/BuffKit/BuffKit.csproj
+++ b/BuffKit/BuffKit.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>BuffKit</AssemblyName>
 		<Product>BuffKit</Product>
 		<Description>Guns of Icarus modding toolkit/moderation mod</Description>
-		<Version>556.0.0</Version>
+		<Version>558.0.0</Version>
 		<LangVersion>latest</LangVersion>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<Configurations>Debug;Release;Release to GameDir;Release to .zip</Configurations>

--- a/BuffKit/GunAnimationFix/GunAnimationFix.cs
+++ b/BuffKit/GunAnimationFix/GunAnimationFix.cs
@@ -9,6 +9,7 @@ namespace BuffKit.GunAnimationFix
     {
         private static bool _enabled = true;
         private static bool _firstMainMenuState = true;
+        //private static bool _testSendSingleFireInput = false;
 
         /// <summary>
         /// Feature initialization. Create settings.
@@ -127,14 +128,14 @@ namespace BuffKit.GunAnimationFix
                     {
                         __instance.shot.transform.rotation = __instance.barrels[__instance.currentBarrel].rotation;
                     }
-                    catch (ArgumentOutOfRangeException ex)
+                    catch (ArgumentOutOfRangeException)
                     {
-                        MuseLog.Error("Out of range happened on {0}. Too many barrels in the data__instance or not enough on the object (index:{1} >= count:{2})".F(new object[]
-                        {
+                        MuseLog.Error("Out of range happened on {0}. Too many barrels in the data__instance or not enough on the object (index:{1} >= count:{2})".F(
+                        [
                     __instance.gameObject.name,
                     __instance.currentBarrel,
                     __instance.barrels != null ? __instance.barrels.Count : 0
-                        }), __instance.gameObject);
+                        ]), __instance.gameObject);
                         if (__instance.barrels != null && __instance.barrels.Count != 0 && __instance.barrels[0] != null)
                         {
                             for (int i = 0; i < __instance.barrels.Count - (__instance.currentBarrel + 1); i++)
@@ -157,7 +158,7 @@ namespace BuffKit.GunAnimationFix
                             RayCastAmmoEffectControls rayCastAmmoEffectControls = __instance.AmmoFX as RayCastAmmoEffectControls;
                             if (rayCastAmmoEffectControls != null)
                             {
-                                Vector3 vector = new Vector3(__instance.cachedTransform.position.x - __instance.Ship.Position.x, 0f, __instance.cachedTransform.position.z - __instance.Ship.Position.z);
+                                Vector3 vector = new(__instance.cachedTransform.position.x - __instance.Ship.Position.x, 0f, __instance.cachedTransform.position.z - __instance.Ship.Position.z);
                                 float num2 = __instance.Ship.AngularVelocity * vector.magnitude;
                                 Vector3 vector2 = Vector3.Cross(Vector3.up, vector.normalized);
                                 rayCastAmmoEffectControls.SetWorldVelocity(__instance.Ship.WorldVelocity + num2 * vector2);
@@ -173,14 +174,14 @@ namespace BuffKit.GunAnimationFix
                                 // END MODIFIED SECTION.
                                 __instance.AmmoFX.PlayMuzzleFlash(__instance.transform, __instance.barrels[__instance.currentBarrel]);
                             }
-                            catch (ArgumentOutOfRangeException ex2)
+                            catch (ArgumentOutOfRangeException)
                             {
-                                MuseLog.Error("Out of range happened on {0}. Too many barrels in the data__instance or not enough on the object (index:{1} >= count:{2})".F(new object[]
-                                {
+                                MuseLog.Error("Out of range happened on {0}. Too many barrels in the data__instance or not enough on the object (index:{1} >= count:{2})".F(
+                                [
                                     __instance.gameObject.name,
                                     __instance.currentBarrel,
                                     __instance.barrels != null ? __instance.barrels.Count : 0
-                                }), __instance.gameObject);
+                                ]), __instance.gameObject);
                                 if (__instance.barrels != null && __instance.barrels.Count != 0 && __instance.barrels[0] != null)
                                 {
                                     for (int j = 0; j < __instance.barrels.Count - (__instance.currentBarrel + 1); j++)
@@ -221,19 +222,28 @@ namespace BuffKit.GunAnimationFix
             return true; // Run original method.
         }
 
+        // Testing method. Do not use. Sends single fire input to actually fire gun on the server.
+        //[HarmonyPatch(typeof(UIManager.UIGunState), nameof(UIManager.UIGunState.ContinuousFireGun))]
+        //[HarmonyPostfix]
+        //private static void UIGunState_ContinuousFireGun(UIManager.UIContext uiContext, UIManager.UIGunState __instance)
+        //{
+        //    if (!_testSendSingleFireInput) return;
+        //    __instance.FireGun(uiContext);
+        //}
+
         // Testing method. Do not use.
-        private static void TestSetContinuousForCurrentGuns(bool enabled)
-        {
-            if (NetworkedPlayer.Local?.CurrentShip == null) return;
-            var guns = NetworkedPlayer.Local.CurrentShip.GetComponentsInChildren<Turret>(true);
-            foreach (var gun in guns)
-            {
-                if (gun == null) continue;
-                if (gun.Continuous != enabled)
-                {
-                    gun.Continuous = enabled;
-                }
-            }
-        }
+        //private static void TestSetContinuousForCurrentGuns(bool enabled)
+        //{
+        //    if (NetworkedPlayer.Local?.CurrentShip == null) return;
+        //    var guns = NetworkedPlayer.Local.CurrentShip.GetComponentsInChildren<Turret>(true);
+        //    foreach (var gun in guns)
+        //    {
+        //        if (gun == null) continue;
+        //        if (gun.Continuous != enabled)
+        //        {
+        //            gun.Continuous = enabled;
+        //        }
+        //    }
+        //}
     }
 }

--- a/BuffKit/GunAnimationFix/GunAnimationFix.cs
+++ b/BuffKit/GunAnimationFix/GunAnimationFix.cs
@@ -42,7 +42,7 @@ namespace BuffKit.GunAnimationFix
                     // Gaze doesn't have it, so I added its type to the check.
                     // Single fire animation highly not recommended. If curious: Gaze and Coil have maximum screen shake.
                     // Gatling and Flamer play trigger down animation repeatedly. Hwacha and Laser trigger down animation doesn't play.
-                    if (__instance.AirshipGunFX.stopTriggerDownEffectSystem != null ||
+                    if (__instance.AirshipGunFX?.stopTriggerDownEffectSystem != null ||
                         __instance.AirshipGunFX is ChargeReleaseFireGunEffectControls /* Gaze and Coil */ )
                     {
                         __instance.PlayContinousFireFX(__instance.localController != null, 1f); // Unmodified.

--- a/BuffKit/ShipLoadoutNotes/ShipLoadoutNotes.cs
+++ b/BuffKit/ShipLoadoutNotes/ShipLoadoutNotes.cs
@@ -11,8 +11,11 @@ using UnityEngine.UI;
 
 namespace BuffKit.ShipLoadoutNotes
 {
-    public class ShipLoadoutNotes : MonoBehaviour
+    internal class ShipLoadoutNotes : MonoBehaviour
     {
+        public static bool Initialized => _shipLoadoutNotesObject is not null;
+        public static bool InputFieldFocused => _noteInputField?.isFocused ?? false;
+
         private static readonly string _name = "Ship Loadout Notes";
         private static readonly string _announceButtonText = "Announce to Crew";
         private static readonly string _saveButtonText = "Save";
@@ -21,9 +24,6 @@ namespace BuffKit.ShipLoadoutNotes
         private static readonly int _maxNoteLength = 1000;
         private static readonly TimeSpan _announceToCrewCooldown = TimeSpan.FromSeconds(15);
 
-        public static bool Initialized { get { return _shipLoadoutNotesObject != null; } }
-        public static bool InputFieldFocused { get { return _noteInputField?.isFocused ?? false; } }
-
         private static TMP_InputField _noteInputField;
         private static GameObject _shipLoadoutNotesObject;
         private static GameObject _announceToCrewButtonObject;
@@ -31,21 +31,15 @@ namespace BuffKit.ShipLoadoutNotes
         private static List<ShipLoadoutNoteData> _allNotes = [];
         private static int _currentNoteIndex = -1;
         private static DateTime? _announcedTime;
-        private static bool _isCaptain { get { return NetworkedPlayer.Local.IsCaptain; } }
+        private static bool _isCaptain => NetworkedPlayer.Local?.IsCaptain ?? false;
 
-        private static ShipLoadoutNoteData _currentGameData
+        private static ShipLoadoutNoteData _currentGameData => new()
         {
-            get
-            {
-                return new ShipLoadoutNoteData
-                {
-                    gameType = NetworkedPlayer.Local.GameType,
-                    shipModelId = UIShipCustomizationScreen.Instance.currentShip.ModelId,
-                    presetIndex = UIShipCustomizationScreen.Instance.currentShip.CurrentPresetIndex,
-                    note = _noteInputField.text
-                };
-            }
-        }
+            gameType = NetworkedPlayer.Local.GameType,
+            shipModelId = UIShipCustomizationScreen.Instance.currentShip.ModelId,
+            presetIndex = UIShipCustomizationScreen.Instance.currentShip.CurrentPresetIndex,
+            note = _noteInputField.text
+        };
 
         [Serializable]
         private struct ShipLoadoutNoteData
@@ -192,7 +186,7 @@ namespace BuffKit.ShipLoadoutNotes
             // Cap length of note. Add length to reserve for player names.
             if (note.Length >= _maxNoteLength + 100) note = note.Substring(0, _maxNoteLength + 100);
             // Split at double newline.
-            var noteParts = note.Split(new string[] { "\n\n" }, StringSplitOptions.RemoveEmptyEntries);
+            var noteParts = note.Split(["\n\n"], StringSplitOptions.RemoveEmptyEntries);
             // Cap at 4 separate chat messages.
             foreach (var notePart in noteParts.Take(4))
             {

--- a/BuffKit/ShipLoadoutNotes/ShipLoadoutNotesPatcher.cs
+++ b/BuffKit/ShipLoadoutNotes/ShipLoadoutNotesPatcher.cs
@@ -3,42 +3,49 @@
 namespace BuffKit.ShipLoadoutNotes
 {
     [HarmonyPatch]
-    public class ShipLoadoutNotesPatcher
+    internal class ShipLoadoutNotesPatcher
     {
         public static bool Enabled { get; private set; } = true;
         private static bool _firstPrepare = true;
 
         private static void Prepare()
         {
-            if (_firstPrepare)
+            if (!_firstPrepare) return;
+            Util.OnGameInitialize += () =>
             {
                 Settings.Settings.Instance.AddEntry("ship loadout notes", "ship loadout notes", v => Enabled = v, Enabled);
-                _firstPrepare = false;
-            }
+            };
+            _firstPrepare = false;
         }
 
-        [HarmonyPatch(typeof(UIShipCustomizationScreen), "SetActiveShip")]
+        /// <summary>
+        /// Initialize and load note. Called when entering the ship customization screen and when a ship loadout is selected.
+        /// </summary>
+        [HarmonyPatch(typeof(UIShipCustomizationScreen), nameof(UIShipCustomizationScreen.SetActiveShip))]
         private static void Postfix()
         {
-            // Called when entering the ship customization screen and when a ship loadout is selected.
             if (!Enabled) return;
             if (!ShipLoadoutNotes.Initialized) ShipLoadoutNotes.Initialize();
             ShipLoadoutNotes.LoadNote();
         }
 
-        [HarmonyPatch(typeof(UIShipCustomizationScreen), "UpdateCamera")]
+        /// <summary>
+        /// Prevents ship preview camera from moving when the text box is focused.
+        /// </summary>
+        [HarmonyPatch(typeof(UIShipCustomizationScreen), nameof(UIShipCustomizationScreen.UpdateCamera))]
         private static bool Prefix()
         {
-            // Prevent ship preview camera from moving when the text box is focused.
             if (!Enabled) return true;
             return !ShipLoadoutNotes.InputFieldFocused;
         }
 
-        [HarmonyPatch(typeof(UIPCChatPanel), "FocusOutgoingMessageField")]
+        /// <summary>
+        /// Prevents enter going to the chat box if the chat box is open.
+        /// </summary>
+        [HarmonyPatch(typeof(UIPCChatPanel), nameof(UIPCChatPanel.FocusOutgoingMessageField))]
         [HarmonyPrefix]
         private static bool PreventChatBoxFocusOnEnter()
         {
-            // Prevent enter going to the chat box if the chat box is open.
             if (!Enabled) return true;
             return !ShipLoadoutNotes.InputFieldFocused;
         }

--- a/BuffKit/ToggleMatchUI/ToggleMatchUIController.cs
+++ b/BuffKit/ToggleMatchUI/ToggleMatchUIController.cs
@@ -3,9 +3,9 @@ using UnityEngine;
 
 namespace BuffKit.ToggleMatchUI
 {
-    public class ToggleUIController : MonoBehaviour
+    internal class ToggleMatchUIController : MonoBehaviour
     {
-        public static ToggleUIController Instance;
+        public static ToggleMatchUIController Instance;
         public static bool Initialized { get; private set; }
         public static bool ShowUI { get; set; }
 
@@ -49,7 +49,7 @@ namespace BuffKit.ToggleMatchUI
 
         private void LateUpdate()
         {
-            if (_kb.GetDown())
+            if (ToggleMatchUIPatcher.EnableKeyBind && _kb.GetDown())
             {
                 ShowUI = !ShowUI;
                 MuseLog.Info($"Setting match UI display to {ShowUI}...");

--- a/BuffKit/ToggleMatchUI/ToggleUIController.cs
+++ b/BuffKit/ToggleMatchUI/ToggleUIController.cs
@@ -1,69 +1,102 @@
-﻿using UnityEngine;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using UnityEngine;
 
 namespace BuffKit.ToggleMatchUI
 {
     public class ToggleUIController : MonoBehaviour
     {
         public static ToggleUIController Instance;
-
         public static bool Initialized { get; private set; }
+        public static bool ShowUI { get; set; }
 
-        private static KeyBinding _kb;
-
-        public bool ShowUI { get; private set; }
-        private List<GameObject> _objectsToHide = new List<GameObject>();
-        private RectTransform _shipHealthFillImageRt;
-        private readonly Vector3 _vector3Zero = Vector3.zero;
+        private static readonly List<GameObject> _objectsToHide = [];
+        private static readonly Vector3 _vector3Zero = Vector3.zero;
+        private static readonly KeyBinding _kb = new(KeyCode.F6);
+        private static RectTransform _shipHealthFillImageRt;
 
         private void Awake()
         {
             Instance = this;
-            _kb = new KeyBinding(KeyCode.F6);
-            // UI object tree
-            _objectsToHide.Add(UIDisplayManager.instance.gameObject.transform.parent.gameObject);
-            // Match chat panel
-            _objectsToHide.Add(GameObject.Find("Menu UI/Standard Canvas/Menu Header Footer/Match Chat Panel"));
-            // First-person equipment object
-            _objectsToHide.Add(GameObject.Find("GameCameraRig/CutScene/MainCamera/FoVOffset/PlayerEquipment"));
 
-            _shipHealthFillImageRt = GameObject.Find("/Game UI/Match UI/UI HUD Canvas/UI HUD/UI Ship Health Display/Health Bar/Ship Health Slider/Fill Area")
-                .GetComponent<RectTransform>();
+            // Cache the objects to hide once and not every initialization.
+            if (_objectsToHide.Count == 0)
+            {
+                // UI object tree.
+                _objectsToHide.Add(UIDisplayManager.instance.gameObject.transform.parent.gameObject);
+                // Match chat panel.
+                _objectsToHide.Add(GameObject.Find("Menu UI/Standard Canvas/Menu Header Footer/Match Chat Panel"));
+                // First-person equipment object.
+                _objectsToHide.Add(GameObject.Find("GameCameraRig/CutScene/MainCamera/FoVOffset/PlayerEquipment"));
+                // Practice mode aim guide.
+                _objectsToHide.Add(AimGuide.Instance.gameObject);
+
+                _shipHealthFillImageRt = GameObject.Find("/Game UI/Match UI/UI HUD Canvas/UI HUD/UI Ship Health Display/Health Bar/Ship Health Slider/Fill Area")
+                    .GetComponent<RectTransform>();
+            }
 
             ShowUI = true;
             Initialized = true;
+            // If UI was hidden when leaving the match, it doesn't show up until the key bind is toggled.
+            // This simulates that and ensures the UI is visible on initialization.
+            ApplyUIState();
         }
+
         private void OnDisable()
         {
+            ShowUI = true;
             Initialized = false;
         }
-        public void LateUpdate()
+
+        private void LateUpdate()
         {
             if (_kb.GetDown())
             {
                 ShowUI = !ShowUI;
-                MuseLog.Info("Show UI change to: " + ShowUI);
-                foreach (var ob in _objectsToHide)
-                    ob.SetActive(ShowUI);
-                if (ShowUI)
-                {
-                    UIRepairComponentView.Activate();
-                    UINameTagDisplay.Activate(); // Doesn't get reactivated until match menu is closed. This fixes that.
-                }
-                else
-                    UIShipDetailsView.HideCrewToolInspectors(0);
+                MuseLog.Info($"Setting match UI display to {ShowUI}...");
+                ApplyUIState();
             }
             // Some things get re-activated elsewhere (e.g. change states, close pause menu, etc.) so disable every update
             if (!ShowUI)
             {
-                UINameTagDisplay.Deactivate();      // Very cheap
-                foreach (var ob in _objectsToHide)
-                    ob.SetActive(false);            // Very cheap
+                UINameTagDisplay.Deactivate();
+                UIRightPanel.Deactivate(); // Practice mode command panel.
+                foreach (var gameObject in _objectsToHide)
+                {
+                    if (gameObject.activeSelf != ShowUI)
+                    {
+                        gameObject.SetActive(ShowUI);
+                    }
+                }
             }
             else
             {
                 // If the ship dies with the UI off, sometimes the position of healthFillImage is set to NaN.
                 _shipHealthFillImageRt.anchoredPosition3D = _vector3Zero;
+            }
+        }
+
+        /// <summary>
+        /// Updates the visibility of UI elements. Intended to be used on key bind toggle and initialization, not every frame.
+        /// </summary>
+        private static void ApplyUIState()
+        {
+            foreach (var gameObject in _objectsToHide)
+            {
+                if (gameObject.activeSelf != ShowUI)
+                {
+                    gameObject.SetActive(ShowUI);
+                }
+            }
+            if (ShowUI)
+            {
+                UIRepairComponentView.Activate();
+                UINameTagDisplay.Activate(); // Doesn't get reactivated until match menu is closed. This fixes that.
+                UIRightPanel.Activate(); // Practice mode command panel.
+            }
+            else
+            {
+                UIShipDetailsView.HideCrewToolInspectors(0);
+                UIRightPanel.Deactivate(); // Practice mode command panel.
             }
         }
     }


### PR DESCRIPTION
### What's New?

- **ToggleMatchUI** [F6]:
  - Fix #30. Thanks Hoboturkey!
  - Hide repair indicators instead of leaving them frozen in place.
  - Hide practice mode command UI and aim guide.
  - Add setting `toggle match ui/enable f6 key bind` enabled by default.
  - UI will always be shown when starting a match.
- **GunAnimationFix**:
  - Fix possible NullReferenceException.
- **ShipLoadoutNotes**:
  - Fix possible NullReferenceException.
- **Developer Changes**:
  - Refactor ToggleMatchUI, removing old reflection code. Rename Patcher to ToggleMatchUIPatcher. Rename ToggleUIController to ToggleMatchUIController.
  - Refactor ShipLoadoutNotes. Rename Patcher to ShipLoadoutNotesPatcher.

[Install/Uninstall Instructions](https://github.com/DrPitLazarus/buffkit#install-options)

gl & hf