### PR TITLE
BuffKit SCS 595 - ShipHealthUI

### DIFF
--- a/BuffKit/BuffKit.csproj
+++ b/BuffKit/BuffKit.csproj
@@ -40,8 +40,8 @@
 	<PropertyGroup>
 		<ZipDir>$(ProjectDir)bin\temp\</ZipDir>
 		<PluginPath>BepInEx\plugins\$(SolutionName)\</PluginPath>
-		<BepInExDownload>https://github.com/BepInEx/BepInEx/releases/download/v5.4.22/BepInEx_x86_5.4.22.0.zip</BepInExDownload>
-		<DownloadFileName>BepInEx_x86_5.4.22.0.zip</DownloadFileName>
+    <DownloadFileName>BepInEx_win_x86_5.4.23.5.zip</DownloadFileName>
+    <BepInExDownload>https://github.com/BepInEx/BepInEx/releases/download/v5.4.23.5/$(DownloadFileName)</BepInExDownload>
 	</PropertyGroup>
 
 	<Target Name="CopyAssemblies">

--- a/BuffKit/BuffKit.csproj
+++ b/BuffKit/BuffKit.csproj
@@ -5,7 +5,7 @@
 		<AssemblyName>BuffKit</AssemblyName>
 		<Product>BuffKit</Product>
 		<Description>Guns of Icarus modding toolkit/moderation mod</Description>
-		<Version>558.0.0</Version>
+		<Version>595.0.0</Version>
 		<LangVersion>latest</LangVersion>
 		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<Configurations>Debug;Release;Release to GameDir;Release to .zip</Configurations>

--- a/BuffKit/Settings/SettingType.cs
+++ b/BuffKit/Settings/SettingType.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Text;
 using BuffKit.UI;
 using Newtonsoft.Json;
@@ -309,6 +310,17 @@ namespace BuffKit.Settings
                         enumName = enumNames[vAsInt];
                     }
                 }
+                //// Add feature to use [Description()] attribute to set custom display text in an enum.
+                var field = enumType.GetField(v.ToString());
+                if (field != null)
+                {
+                    var attributes = field.GetCustomAttributes(typeof(DescriptionAttribute), false);
+                    if (attributes.Length > 0 && attributes[0] is DescriptionAttribute attr)
+                    {
+                        enumName = attr.Description;
+                    }
+                }
+                //// End [Description()] attribute.
                 _enumNames.Add(enumName);
                 if (vAsInt == value)
                     valueValid = true;

--- a/BuffKit/ShipHealthUI/ShipHealthUI.cs
+++ b/BuffKit/ShipHealthUI/ShipHealthUI.cs
@@ -1,0 +1,142 @@
+﻿using BuffKit.Settings;
+using HarmonyLib;
+using System.ComponentModel;
+using TMPro;
+using UnityEngine;
+using Resources = BuffKit.UI.Resources;
+
+namespace BuffKit.ShipHealthUI;
+
+[HarmonyPatch]
+internal class ShipHealthUI : MonoBehaviour
+{
+    private static bool _firstMainMenuState = true;
+    private static readonly int _fontSize = 12;
+    private static GameObject _mainObject;
+    private static TextMeshProUGUI _textMeshProUGUI;
+    private static ShipHealthDisplayOption _shipHealthDisplayOption = ShipHealthDisplayOption.Disabled;
+    private static readonly string[] _displayOptionTextFormat =
+    [
+        "",
+        "<mspace=2em>{0:0}/{1:0}</mspace> (<mspace=2em>{2:0}</mspace>%)",
+        "<mspace=2em>{0:0}/{1:0}",
+        "<mspace=2em>{2:0}</mspace>%"
+    ];
+    private static string _selectedTextFormat => _displayOptionTextFormat[(int)_shipHealthDisplayOption];
+    private static Ship _currentShip => NetworkedPlayer.Local?.CurrentShip;
+    private static Hull _currentShipHull => NetworkedPlayer.Local?.CurrentShip?.ActiveHull;
+
+    private enum ShipHealthDisplayOption
+    {
+        Disabled,
+        [Description("Number and Percent")]
+        NumberAndPercent,
+        Number,
+        Percent,
+    }
+
+    /// <summary>
+    /// Feature initialization. Create settings.
+    /// </summary>
+    [HarmonyPatch(typeof(UIManager.UINewMainMenuState), nameof(UIManager.UINewMainMenuState.Enter))]
+    [HarmonyPostfix]
+    private static void Start()
+    {
+        if (!_firstMainMenuState) return;
+        _firstMainMenuState = false;
+        Settings.Settings.Instance.AddEntry("ship health ui", "ship health ui display",
+            v => { _shipHealthDisplayOption = (ShipHealthDisplayOption)v.SelectedValue; },
+            new EnumString(typeof(ShipHealthDisplayOption), (int)_shipHealthDisplayOption));
+
+        if (_mainObject == null)
+        {
+            MuseLog.Info("GameObject created!");
+            _mainObject = CreateUi();
+            _mainObject.SetActive(false);
+        }
+    }
+
+    private static GameObject CreateUi()
+    {
+        var parentObject = GameObject.Find("/Game UI/Match UI/UI HUD Canvas/UI HUD/UI Ship Health Display/Health Bar");
+        var mainObject = new GameObject("ShipHealthUI");
+        mainObject.transform.SetParent(parentObject.transform, false);
+        var rectTransform = mainObject.AddComponent<RectTransform>();
+        rectTransform.anchorMax = Vector2.zero;
+        rectTransform.anchorMin = Vector2.zero;
+        rectTransform.pivot = new Vector2(0, 1);
+        rectTransform.localPosition = new Vector3(rectTransform.localPosition.x, -19, 0);
+        var textMesh = mainObject.AddComponent<TextMeshProUGUI>();
+        textMesh.font = Resources.FontPenumbraHalfSerifStd;
+        textMesh.text = "<mspace=2em>9999/9999";
+        textMesh.fontSize = _fontSize;
+        _textMeshProUGUI = textMesh;
+        mainObject.AddComponent<ShipHealthUI>();
+        return mainObject;
+    }
+
+    // Old update method, moved to event based updates instead of every frame.
+    //private void LateUpdate()
+    //{
+    //    UpdateUI();
+    //}
+
+    /// <summary>
+    /// Any time a ship adds a hull, check if the calling ship is the player's and update the UI.
+    /// </summary>
+    [HarmonyPatch(typeof(Ship), nameof(Ship.AddHull))]
+    [HarmonyPostfix]
+    private static void Ship_AddHull(Ship __instance)
+    {
+        var playerShip = _currentShip;
+        if (playerShip == null) return;
+        var callingShipIsPlayers = ReferenceEquals(__instance, playerShip);
+        if (!callingShipIsPlayers) return;
+        UpdateUI();
+    }
+
+    /// <summary>
+    /// Any time a hull is remotely updated, check if the calling hull is the player's and update the UI.
+    /// </summary>
+    [HarmonyPatch(typeof(Hull), nameof(Hull.OnRemoteUpdate))]
+    [HarmonyPostfix]
+    private static void Hull_OnRemoteUpdate(Hull __instance)
+    {
+        var playerHull = _currentShipHull;
+        if (playerHull == null) return;
+        var callingHullIsPlayers = ReferenceEquals(__instance, playerHull);
+        if (!callingHullIsPlayers) return;
+        UpdateUI();
+    }
+
+    /// <summary>
+    /// Updates and sets the text for the UI.
+    /// </summary>
+    private static void UpdateUI()
+    {
+        var hull = _currentShipHull;
+        if (hull == null) return;
+        var newText = _selectedTextFormat.F([hull.CoreHealth, hull.MaxCoreHealth, hull.PercentCoreHealth]);
+        if (newText != _textMeshProUGUI.text) _textMeshProUGUI.text = newText;
+    }
+
+    [HarmonyPatch(typeof(UIManager.UIMatchBlockState), nameof(UIManager.UIMatchBlockState.Exit))] // Normal match start.
+    [HarmonyPatch(typeof(UIManager.UILoadingBlockState), nameof(UIManager.UILoadingBlockState.Exit))] // Join running match.
+    [HarmonyPostfix]
+    private static void UIManager_UIMatchBlockState_Exit()
+    {
+        if (_shipHealthDisplayOption == ShipHealthDisplayOption.Disabled) return;
+        var shouldBeEnabled = Util.MissionIsNotPvP();
+        MuseLog.Info($"shouldBeEnabled: {shouldBeEnabled}");
+        if (!shouldBeEnabled) return;
+        MuseLog.Info($"Activating with display option: {_shipHealthDisplayOption}.");
+        _mainObject.SetActive(true);
+    }
+
+    [HarmonyPatch(typeof(Mission), nameof(Mission.OnDisable))]
+    [HarmonyPostfix]
+    private static void Mission_OnDisable()
+    {
+        if (_mainObject != null && _mainObject.activeSelf) _mainObject.SetActive(false);
+    }
+}

--- a/BuffKit/ShipHealthUI/ShipHealthUI.cs
+++ b/BuffKit/ShipHealthUI/ShipHealthUI.cs
@@ -40,7 +40,7 @@ internal class ShipHealthUI : MonoBehaviour
     /// </summary>
     [HarmonyPatch(typeof(UIManager.UINewMainMenuState), nameof(UIManager.UINewMainMenuState.Enter))]
     [HarmonyPostfix]
-    private static void Start()
+    private static void Initialize()
     {
         if (!_firstMainMenuState) return;
         _firstMainMenuState = false;
@@ -83,15 +83,27 @@ internal class ShipHealthUI : MonoBehaviour
 
     /// <summary>
     /// Any time a ship adds a hull, check if the calling ship is the player's and update the UI.
+    /// Sometimes does not work... It is always something...
     /// </summary>
-    [HarmonyPatch(typeof(Ship), nameof(Ship.AddHull))]
+    //[HarmonyPatch(typeof(Ship), nameof(Ship.AddHull))]
+    //[HarmonyPostfix]
+    //private static void Ship_AddHull(Ship __instance)
+    //{
+    //    var playerShip = _currentShip;
+    //    if (playerShip == null) return;
+    //    var callingShipIsPlayers = ReferenceEquals(__instance, playerShip);
+    //    if (!callingShipIsPlayers) return;
+    //    UpdateUI();
+    //}
+
+    /// <summary>
+    /// Any time a player's parent is changed, update the UI. Change occurs on ship death and spawn.
+    /// Should run less often than polling frequently.
+    /// </summary>
+    [HarmonyPatch(typeof(NetworkedPlayer), nameof(NetworkedPlayer.OnParentChange))]
     [HarmonyPostfix]
-    private static void Ship_AddHull(Ship __instance)
+    private static void NetworkedPlayer_OnParentChange()
     {
-        var playerShip = _currentShip;
-        if (playerShip == null) return;
-        var callingShipIsPlayers = ReferenceEquals(__instance, playerShip);
-        if (!callingShipIsPlayers) return;
         UpdateUI();
     }
 
@@ -110,6 +122,16 @@ internal class ShipHealthUI : MonoBehaviour
     }
 
     /// <summary>
+    /// Clear UI on ship death so it does not briefly appear on next spawn.
+    /// </summary>
+    [HarmonyPatch(typeof(NetworkedPlayer), nameof(NetworkedPlayer.OnShipDeath))]
+    [HarmonyPostfix]
+    private static void NetworkedPlayer_OnShipDeath()
+    {
+        _textMeshProUGUI.text = "";
+    }
+
+    /// <summary>
     /// Updates and sets the text for the UI.
     /// </summary>
     private static void UpdateUI()
@@ -120,6 +142,9 @@ internal class ShipHealthUI : MonoBehaviour
         if (newText != _textMeshProUGUI.text) _textMeshProUGUI.text = newText;
     }
 
+    /// <summary>
+    /// Activate feature.
+    /// </summary>
     [HarmonyPatch(typeof(UIManager.UIMatchBlockState), nameof(UIManager.UIMatchBlockState.Exit))] // Normal match start.
     [HarmonyPatch(typeof(UIManager.UILoadingBlockState), nameof(UIManager.UILoadingBlockState.Exit))] // Join running match.
     [HarmonyPostfix]
@@ -133,6 +158,9 @@ internal class ShipHealthUI : MonoBehaviour
         _mainObject.SetActive(true);
     }
 
+    /// <summary>
+    /// Deactivate feature.
+    /// </summary>
     [HarmonyPatch(typeof(Mission), nameof(Mission.OnDisable))]
     [HarmonyPostfix]
     private static void Mission_OnDisable()

--- a/BuffKit/ShipLoadoutViewer/Patcher.cs
+++ b/BuffKit/ShipLoadoutViewer/Patcher.cs
@@ -81,4 +81,19 @@ namespace BuffKit.ShipLoadoutViewer
             ShipLoadoutViewer.PaintLoadoutBars(___mlv);
         }
     }
+
+    /// <summary>
+    /// Fix display of crew slot player names when the name is too long or squished by loadout/faction icons.
+    /// </summary>
+    [HarmonyPatch]
+    internal class FixPlayerNameWordWrap
+    {
+        [HarmonyPatch(typeof(UILobbyCrewSlot), nameof(UILobbyCrewSlot.Initialize))]
+        [HarmonyPostfix]
+        private static void Initialize(UILobbyCrewSlot __instance)
+        {
+            __instance.playerLevelText.resizeTextForBestFit = true;
+            __instance.playerNameText.resizeTextForBestFit = true;
+        }
+    }
 }

--- a/BuffKit/UpdateChecker/UpdateChecker.cs
+++ b/BuffKit/UpdateChecker/UpdateChecker.cs
@@ -1,5 +1,7 @@
 ﻿using HarmonyLib;
+using LitJson;
 using MuseBase.Multiplayer;
+using System;
 using System.Collections;
 using UnityEngine;
 using UnityEngine.Networking;
@@ -10,11 +12,14 @@ namespace BuffKit.UpdateChecker
     [HarmonyPatch]
     public class UpdateChecker : MonoBehaviour
     {
-        private static readonly string _serverVersionUrl = "https://drpitlazarus.github.io/goi-mods/buffkit-version";
-        private static readonly string _latestReleasePageUrl = "https://github.com/DrPitLazarus/buffkit/releases/latest";
         private static readonly string _chatCommandToOpenDownloadPage = "/buffkit update";
+        private static readonly string _gitHubReleasesUrl = "https://api.github.com/repos/drpitlazarus/buffkit/releases";
+        private static readonly string _gitHubReleasesTag = "SCS";
+        private static readonly string _chatCommandToOpenGitHubPage = "/buffkit github";
+        private static readonly string _gitHubUrl = "https://github.com/DrPitLazarus/buffkit";
         private static bool _firstMainMenuState = true;
         private static UpdateChecker _instance;
+        private static string _latestReleasePageUrl;
 
         [HarmonyPatch(typeof(UIManager.UINewMainMenuState), nameof(UIManager.UINewMainMenuState.Enter))]
         [HarmonyPostfix]
@@ -33,15 +38,13 @@ namespace BuffKit.UpdateChecker
         /// <summary>
         /// Log current version in chat and check for updates. If outdated, log an update available message in chat.
         /// </summary>
-        /// <returns></returns>
         private IEnumerator CheckForUpdates()
         {
             var currentVersion = PluginInfo.PLUGIN_VERSION;
             MuseLog.Info($"Current BuffKit version: {currentVersion}.");
             Util.SendConsoleChatMessage($"BuffKit {currentVersion} loaded.");
 
-            // Using Unity's version since WebClient/HttpWebRequest fails to connect to https URLs.
-            var request = UnityWebRequest.Get(_serverVersionUrl);
+            var request = UnityWebRequest.Get(_gitHubReleasesUrl);
             yield return request.Send(); // Wait for the request to complete without blocking.
             if (request.isError || request.responseCode != 200)
             {
@@ -49,30 +52,67 @@ namespace BuffKit.UpdateChecker
                 yield break; // Early return.
             }
 
-            var versionFromServer = request.downloadHandler.text.Trim();
-            MuseLog.Info($"Latest BuffKit version: {versionFromServer}.");
-
-            var isOutdated = new Version(currentVersion).CompareTo(new Version(versionFromServer)) < 0; // -1 means the server version is newer.
-            if (!isOutdated)
+            try
             {
-                yield break; // Early return.
+                var releasesJson = JsonMapper.ToObject(request.downloadHandler.text);
+                var foundLatestRelease = false;
+                var serverVersionString = "";
+                foreach (JsonData release in releasesJson)
+                {
+                    if (release["tag_name"].ToString().StartsWith(_gitHubReleasesTag))
+                    {
+                        foundLatestRelease = true;
+                        serverVersionString = release["tag_name"].ToString().Replace(_gitHubReleasesTag, "");
+                        var parts = serverVersionString.Split('.').Length;
+                        if (parts == 1)
+                            serverVersionString += ".0.0";
+                        else if (parts == 2)
+                            serverVersionString += ".0";
+                        MuseLog.Info($"Latest {PluginInfo.PLUGIN_NAME} version: {serverVersionString}.");
+                        _latestReleasePageUrl = release["html_url"].ToString();
+                        break;
+                    }
+                }
+
+                if (!foundLatestRelease)
+                {
+                    throw new Exception($"Did not find a release with the expected tag format ({_gitHubReleasesTag}<version>).");
+                }
+
+                var isOutdated = new Version(currentVersion).CompareTo(new Version(serverVersionString)) < 0; // -1 means the server version is newer.
+                if (!isOutdated)
+                {
+                    MuseLog.Info("No update available.");
+                    yield break; // Early return.
+                }
+                var message = $"{PluginInfo.PLUGIN_NAME} {serverVersionString} is available. Type \"{_chatCommandToOpenDownloadPage}\" to open download page.";
+                Util.SendConsoleChatMessage(message);
             }
-            var message = $"BuffKit {versionFromServer} is available. Type \"{_chatCommandToOpenDownloadPage}\" to open download page.";
-            Util.SendConsoleChatMessage(message);
+            catch (Exception ex)
+            {
+                MuseLog.Info($"Failed to check for update. Error: {ex.Message}");
+            }
         }
 
         /// <summary>
-        /// Prefix patch to prevent sending chat command as a message and open the download page.
+        /// Prefix patch to prevent sending chat command as a message and run actions.
         /// </summary>
-        /// <param name="msg"></param>
-        /// <returns></returns>
         [HarmonyPatch(typeof(MessageClient), nameof(MessageClient.TrySendMessage))]
         [HarmonyPrefix]
         private static bool HandleChatCommandToOpenDownloadPage(string msg)
         {
-            if (msg.ToLower().Trim() != _chatCommandToOpenDownloadPage) return true; // Allow other messages to be sent normally.
-            Application.OpenURL(_latestReleasePageUrl);
-            return false; // Prevent the message from being sent to the server.
+            var preparedMsg = msg.ToLower().Trim();
+            if (preparedMsg == _chatCommandToOpenDownloadPage)
+            {
+                Application.OpenURL(_latestReleasePageUrl);
+                return false; // Prevent the message from being sent to the server.
+            }
+            if (preparedMsg == _chatCommandToOpenGitHubPage)
+            {
+                Application.OpenURL(_gitHubUrl);
+                return false;
+            }
+            return true; // Allow other messages to be sent normally.
         }
     }
 }

--- a/BuffKit/Util/Util.cs
+++ b/BuffKit/Util/Util.cs
@@ -254,5 +254,19 @@ namespace BuffKit
             MuseWorldClient.Instance.ChatHandler.AddMessage(ChatMessage.Console(message));
         }
 
+        /// <summary>
+        /// Available after a match starts. Used to control features that should not be enabled in PvP modes.
+        /// </summary>
+        public static bool MissionIsNotPvP()
+        {
+            var currentGameMode = Mission.Instance?.Map?.GameMode;
+            if (currentGameMode == null) return false;
+            // Pirate Deathmatch 1 ship = RegionGameMode.NOVICE_DEATHMATCH. Jester's Parade is not a serious mode.
+            if (currentGameMode == RegionGameMode.NOVICE_DEATHMATCH
+                || Mission.Instance.Map.Name == "Test_Race_OblivionApproach_FFA")
+                return true;
+            var isPvP = RegionGameModeUtil.IsSkirmish((RegionGameMode)currentGameMode);
+            return !isPvP;
+        }
     }
 }

--- a/BuffKitModInstaller/FormMain.cs
+++ b/BuffKitModInstaller/FormMain.cs
@@ -1,10 +1,12 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Runtime.InteropServices;
-using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -19,12 +21,12 @@ namespace BuffKitModInstaller
         static readonly string _gameFileName = "GunsOfIcarusOnline.exe";
         static readonly string _modRelativeFilePath = @"BepInEx\plugins\BuffKit\BuffKit.dll";
         static readonly string _modRelativeDirectory = Path.GetDirectoryName(_modRelativeFilePath);
-        // Source: https://github.com/DrPitLazarus/goi-mods/blob/gh-pages/docs/buffkit-mod-installer-versions.json
-        static readonly string _installerVersionsUrl = "https://drpitlazarus.github.io/goi-mods/buffkit-mod-installer-versions.json";
-        // Source: https://github.com/DrPitLazarus/goi-mods/blob/gh-pages/docs/buffkit-versions.json
-        static readonly string _versionsUrl = "https://drpitlazarus.github.io/goi-mods/buffkit-versions.json";
+        static readonly string _installerReleaseTag = "Installer-SCS";
+        static readonly string _modReleaseTag = "SCS";
+        static readonly string _versionsUrl = "https://api.github.com/repos/drpitlazarus/buffkit/releases";
         static readonly string _githubUrl = "https://github.com/DrPitLazarus/buffkit";
         static string _gameDirectory = @"C:\Program Files (x86)\Steam\steamapps\common\Guns of Icarus Online";
+        static JsonArray _releasesJson;
         public static ModVersion[] ModVersions = [];
 
         public struct ModVersion
@@ -70,6 +72,8 @@ namespace BuffKitModInstaller
             Text = $"{Application.ProductName} {_applicationVersion}";
             linkLabelOpenModDir.Text = _modRelativeDirectory;
             SetStatusLabelText("");
+            _httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("BuffKitModInstaller");
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/vnd.github.v3+json"));
         }
 
         async void FormMain_Shown(object sender, EventArgs e)
@@ -89,23 +93,39 @@ namespace BuffKitModInstaller
         {
             try
             {
-                using HttpResponseMessage response = await _httpClient.GetAsync(_installerVersionsUrl);
+                using HttpResponseMessage response = await _httpClient.GetAsync(_versionsUrl);
                 response.EnsureSuccessStatusCode();
-                var jsonString = (await response.Content.ReadAsStringAsync()).ToString().Trim();
-                var versions = JsonSerializer.Deserialize<ModVersion[]>(jsonString);
-                var latestVersion = versions[0];
-                if (!VersionIsOutdated(_applicationVersion, latestVersion.version))
+                var jsonString = await response.Content.ReadAsStringAsync();
+                var jsonRoot = JsonNode.Parse(jsonString) as JsonArray;
+                _releasesJson = jsonRoot;
+                var serverVersionString = "";
+                var releaseUrl = "";
+                foreach (var release in jsonRoot)
+                {
+                    if (release["tag_name"].ToString().StartsWith(_installerReleaseTag))
+                    {
+                        releaseUrl = release["html_url"].ToString();
+                        serverVersionString = release["tag_name"].ToString().Replace(_installerReleaseTag, "");
+                        var parts = serverVersionString.Split('.').Length;
+                        if (parts == 1)
+                            serverVersionString += ".0.0";
+                        else if (parts == 2)
+                            serverVersionString += ".0";
+                        break;
+                    }
+                }
+                if (!VersionIsOutdated(_applicationVersion, serverVersionString))
                 {
                     return;
                 }
-                var message = $"Latest Version: {latestVersion.version}\n" +
+                var message = $"Latest Version: {serverVersionString}\n" +
                     $"Current Version: {_applicationVersion}\n\n" +
                     $"Press OK to open the release page in your web browser and exit.\n" +
                     $"Press Cancel to continue without updating.";
                 var result = MessageBox.Show(message, $"{Application.ProductName} Update Available", MessageBoxButtons.OKCancel, MessageBoxIcon.Information, MessageBoxDefaultButton.Button1);
                 if (result == DialogResult.OK)
                 {
-                    Process.Start(latestVersion.releaseUrl);
+                    Process.Start(releaseUrl);
                     Environment.Exit(0);
                 }
             }
@@ -160,10 +180,41 @@ namespace BuffKitModInstaller
         {
             try
             {
-                using HttpResponseMessage response = await _httpClient.GetAsync(_versionsUrl);
-                response.EnsureSuccessStatusCode();
-                var jsonString = (await response.Content.ReadAsStringAsync()).ToString().Trim();
-                ModVersions = JsonSerializer.Deserialize<ModVersion[]>(jsonString);
+                if (_releasesJson == null)
+                {
+                    using HttpResponseMessage response = await _httpClient.GetAsync(_versionsUrl);
+                    response.EnsureSuccessStatusCode();
+                    var jsonString = await response.Content.ReadAsStringAsync();
+                    var jsonRoot = JsonNode.Parse(jsonString) as JsonArray;
+                    _releasesJson = jsonRoot;
+                }
+                List<ModVersion> modVersions = [];
+                foreach (var release in _releasesJson)
+                {
+                    if (release["tag_name"].ToString().StartsWith(_modReleaseTag))
+                    {
+                        var releaseUrl = release["html_url"].ToString();
+                        var downloadUrl = release["assets"]![0]!["browser_download_url"].ToString();
+                        var versionString = release["tag_name"].ToString().Replace(_modReleaseTag, "");
+                        var parts = versionString.Split('.').Length;
+                        if (parts == 1)
+                        {
+                            // Limit supported versions for the installer. Fails because .zip structure is different.
+                            if (int.TryParse(versionString, out int versionInt) && versionInt < 486)
+                                break;
+                            versionString += ".0.0";
+                        }
+                        else if (parts == 2)
+                            versionString += ".0";
+                        modVersions.Add(new ModVersion
+                        {
+                            version = versionString,
+                            downloadUrl = downloadUrl,
+                            releaseUrl = releaseUrl,
+                        });
+                    }
+                }
+                ModVersions = [.. modVersions];
                 labelLatestVersion.Text = ModVersions[0].version;
             }
             catch (Exception ex)

--- a/BuffKitModInstaller/Properties/AssemblyInfo.cs
+++ b/BuffKitModInstaller/Properties/AssemblyInfo.cs
@@ -30,4 +30,4 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 [assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("548.0.0.0")]
+[assembly: AssemblyFileVersion("595.0.0.0")]

--- a/BuffKitModInstaller/README.md
+++ b/BuffKitModInstaller/README.md
@@ -4,7 +4,7 @@ Windows program to install, update, or uninstall BuffKit.
 ![image](https://github.com/user-attachments/assets/2a1b14a1-bb82-4a95-b9bf-3e50b9a5cb26)
 
 ### Download
-Visit the [release page](https://github.com/DrPitLazarus/buffkit/releases/tag/Installer-SCS548). Current version is SCS 548.
+Visit the [release page](https://github.com/DrPitLazarus/buffkit/releases/tag/Installer-SCS595). Current version is SCS 595.
 
 ### Features
 - Install Latest Version


### PR DESCRIPTION
### What's New?

- New **ShipHealthUI**:
  - Displays ship core health as number and/or percent under ship health bar. Requested by Tindwunnel.
  - Available in non-PvP matches.
  - Add setting `ship health ui/ship health ui display: [Disabled (default), Number and Percent, Number, Percent]`.
![ShipHealthUI](https://github.com/user-attachments/assets/26e26422-38c1-4491-a64a-b2a84633fb1a)

- **ShipLoadoutViewer**:
  - Fix player name display issues: Names used to disappear/cut off if name is long and squished by crew loadout/faction icons.
- **UpdateChecker**:
  - Add chat command `/buffkit github` to open BuffKit GitHub page.
- **Developer Changes**:
  - [Update BepInEx 5.4.22.0 -> 5.4.23.5](https://github.com/DrPitLazarus/buffkit/commit/134866ee04df4fe5e87ab18afa48134bdeb64030)
  - [UpdateChecker Use GitHub Releases API](https://github.com/DrPitLazarus/buffkit/commit/7477c30e744e5f9d5a54f8aec6198faa49c2512e)
  - [Util Add MissionIsNotPVP Method](https://github.com/DrPitLazarus/buffkit/commit/775848a9e8cf3765c0f69a1c846b9a96b3875e17)
  - [Settings Add Description Attribute Support for Enums](https://github.com/DrPitLazarus/buffkit/commit/38f63bd2f2aeeed6dd1072576d4a15517aff2806)

[Install/Uninstall Instructions](https://github.com/DrPitLazarus/buffkit#install-options)

gl & hf